### PR TITLE
Fix the hex package contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## v0.2.0
+
+* Bug fixes
+  * Fixed crash on stop_listening/0
+  * Added missing files to hex.pm release
+
+## v0.1.0
+
+* Initial hex.pm release

--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,19 @@
-Copyright (c) 2015, Jim Freeze
+Copyright (c) 2015-2018 Jim Freeze
 
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ex_ncurses
 
+[![Hex version](https://img.shields.io/hexpm/v/ex_ncurses.svg "Hex version")](https://hex.pm/packages/ex_ncurses)
+
 Ncurses NIF for Elixir
 
 ## What It Does
@@ -20,13 +22,13 @@ ExNcurses.
 
 ## Installation
 
-The package is available on [github](https://github.com/jfreeze/ex_ncurses) can
+The package is available on [hex.pm](https://hex.pm/packages/ex_ncurses) and can
 be installed by adding `ex_ncurses` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:ex_ncurses, git: "https://github.com/jfreeze/ex_ncurses.git"}
+    {:ex_ncurses, "~> 0.1"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ For usage, you can look at the code in the `examples` directory or check out the
 QuickieSynth sample project (@elixirsips) where we show a version using
 ExNcurses.
 
-   [github.com/jfreeze/ex_ncurses](https://github.com/jfreeze/ex_ncurses)
-
 ## Installation
 
 The package is available on [hex.pm](https://hex.pm/packages/ex_ncurses) and can

--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,8 @@ defmodule ExNcurses.MixProject do
       name: :ex_ncurses,
       maintainers: ["Jim Freeze, Frank Hunleth, Justin Schneck"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/jfreeze/ex_ncurses"}
+      links: %{"GitHub" => "https://github.com/jfreeze/ex_ncurses"},
+      files: ["LICENSE", "README.md", "lib/**/*.ex", "mix.exs", "Makefile", "src/*.c"]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExNcurses.MixProject do
   def project do
     [
       app: :ex_ncurses,
-      version: "0.1.0",
+      version: "0.2.0",
       package: package(),
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
It turned out that not all of the files were included in the package posted to hex.pm. This PR should fix the issue. I also updated the README.md to point to hex.pm rather than the Github location.

@jfreeze I'll be busy on some other things the next several days so I don't think that I'll have any more updates coming for a bit. If you get a chance, could you post an updated release to hex?